### PR TITLE
Fix パスワード変更時にバリデーションを表示させるように変更

### DIFF
--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -31,9 +31,14 @@ class PasswordResetsController < ApplicationController
       render :edit, status: :unprocessable_entity
       return
     end
+    password_update(@user)
+  end
 
-    @user.password_confirmation = params[:user][:password_confirmation]
-    if @user.change_password(params[:user][:password])
+  private
+
+  def password_update(user)
+    user.password_confirmation = params[:user][:password_confirmation]
+    if user.change_password(params[:user][:password])
       flash[:notice] = "パスワードを変更しました"
       redirect_to login_path
     else

--- a/app/controllers/password_resets_controller.rb
+++ b/app/controllers/password_resets_controller.rb
@@ -26,6 +26,10 @@ class PasswordResetsController < ApplicationController
     if @user.blank?
       not_authenticated
       return
+    elsif params[:user][:password].blank?
+      flash.now[:alert] = "パスワードの変更に失敗しました パスワードが空です"
+      render :edit, status: :unprocessable_entity
+      return
     end
 
     @user.password_confirmation = params[:user][:password_confirmation]
@@ -34,7 +38,7 @@ class PasswordResetsController < ApplicationController
       redirect_to login_path
     else
       flash.now[:alert] = "パスワードの変更に失敗しました"
-      render :action => "edit", status: :unprocessable_entity
+      render :edit, status: :unprocessable_entity
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,10 +2,9 @@ class User < ApplicationRecord
   authenticates_with_sorcery!
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
-  validates :password, presence: true, length: { minimum: 5, maximum: 40 }, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'は英数字の混合である必要があります' }, on: :create, if: lambda {
+  validates :password, presence: true, confirmation: true, length: { minimum: 5, maximum: 40 }, format: { with: /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i, message: 'は英数字の混合である必要があります' }, if: lambda {
     new_record? || changes[:crypted_password]
   } 
-  validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
   validates :reset_password_token, uniqueness: true, allow_nil: true
   validates :instagram_account_url, allow_blank: true, format: { with: %r{\Ahttps://(?:www\.)?instagram\.com/[a-zA-Z0-9._%+-]+(=[^&]*)?(\?.+)?\z} }

--- a/spec/system/password_resets_spec.rb
+++ b/spec/system/password_resets_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe "PasswordResets", type: :system do
       click_button "送信"
       expect(page).to have_content "メールを送信しました"
       visit edit_password_reset_path(user.reload.reset_password_token)
-      fill_in 'パスワード', with: '123456789'
-      fill_in 'パスワード確認', with: '123456789'
+      fill_in 'パスワード', with: '1234b'
+      fill_in 'パスワード確認', with: '1234b'
       click_button '送信'
       expect(page).to have_content "パスワードを変更しました"
     end


### PR DESCRIPTION
- [x] Userモデルのpasswordバリデーションが2カ所あり1カ箇所へまとめ
- [x] Userモデルのpasswordバリデーションがcreateのみに実行されていたので、updateのときにも反映されるように変更
- [x] パスワード変更のフォームに空文字を入れたときに、エラーとして表示するように変更