### PR TITLE
Fix require line/bot を削除

### DIFF
--- a/app/controllers/line_bots_controller.rb
+++ b/app/controllers/line_bots_controller.rb
@@ -1,5 +1,4 @@
 class LineBotsController < ApplicationController
-  require 'line/bot'
   protect_from_forgery :except => [:webhook]
   skip_before_action :require_login, only: [:webhook]
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,4 @@
 class PostsController < ApplicationController
-  require 'line/bot'
   skip_before_action :require_login, only: %i[index show]
 
   def index


### PR DESCRIPTION
- [x] Railsでは、config/application.rbにて、Bundler.require(*Rails.groups)となっており、個別にrequireする必要がなかった為削除