### PR TITLE
Remove auth_paramsにて必要な値のみ取得

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -22,7 +22,7 @@ class OauthsController < ApplicationController
   private
 
   def auth_params
-    params.permit(:code, :provider, :error, :state)
+    params.permit(:code, :provider)
   end
 
 end


### PR DESCRIPTION
- [x] paramsでcode(認可コード)を取得し、アプリ側にてアクセストークンを取得する。